### PR TITLE
feat(telegram): send and receive JPEG/PNG images

### DIFF
--- a/docs/telegram-images.md
+++ b/docs/telegram-images.md
@@ -1,0 +1,71 @@
+# Telegram images
+
+The Telegram bridge can receive photos (including captions) and JPEG/PNG
+images sent as documents. The largest photo variant is downloaded once; photo
+variants are alternate sizes, not separate attachments. Albums arrive as
+individual messages. GIFs, stickers, video and arbitrary documents are outside
+this feature.
+
+Incoming images are validated and saved with random names and mode `0600` in
+`$H2_DIR/attachments/<bridge-name>/` (directory mode `0700`). Original remote
+filenames are never used locally. The agent receives the caption and an
+absolute local image path in its normal message, including normal
+expects-response handling. It must use its image-viewing tool to inspect the
+image: this is not native image injection into a harness's prompt. The agent
+needs filesystem access to the attachments directory and an image-viewing tool.
+
+`agent-name:` prefixes in captions and replies to agent-tagged image captions
+route just like text messages. Captions are not executed as slash commands.
+Only messages from the configured chat are downloaded. Images are not fetched
+from arbitrary links in user text.
+
+## Send a local image
+
+```sh
+h2 send telegram --image ./screenshot.png "Here is the screenshot"
+h2 send telegram --image ./screenshot.png
+h2 send --closes <trigger-id> telegram --image ./result.png "Result"
+```
+
+Replace `telegram` with your configured bridge name. The optional body (or
+`--file` contents) is a plain-text caption. Non-concierge sender tags are added
+as for text. `--closes` sends the image successfully before removing the reminder.
+`--raw`, `--expects-response` and agent targets are not supported with `--image`.
+Symlinks and non-regular files are rejected. Files are read by the local bridge
+process, under the same user as the CLI. The path is explicitly selected via
+`--image`; paths mentioned in ordinary message bodies never trigger uploads.
+
+An optional bridge `ImageSender` capability leaves text-only bridges unchanged.
+A separate `send-image` socket operation makes older bridges reject unsupported
+image requests instead of silently sending only the caption. Restart the bridge
+with the updated binary before using images. No other daemon/harness needs image
+protocol changes for incoming images; they receive ordinary text with a path.
+
+## Bounds, privacy and errors
+
+- JPEG/PNG only, at most 10 MiB and 40 megapixels. Both metadata and actual
+  downloaded bytes are checked, and the image is decoded to detect corrupt data.
+- Plain captions are limited to 1024 characters, including any sender tag.
+  Overlong captions are rejected, never silently truncated.
+- Image HTTP operations have a 60-second deadline and do not follow redirects.
+  Download paths are validated and token-bearing request URLs are not included
+  in image errors. API response bodies are not echoed in image errors.
+- Failed downloads produce a visible error, not a caption that pretends the
+  image arrived. No partial local image is retained on a failed write.
+- Attachments persist for delayed agent delivery and session history. There is
+  no automatic expiration or total-storage quota in this change. Monitor disk
+  usage and remove old attachments when they are no longer needed; removing
+  them will make historical image references unreadable. Do not commit this
+  private attachment directory or expose it through a web server.
+- A failed outbound request can be ambiguous if Telegram accepted the image but
+  the connection failed before the response. Uploads are not automatically retried.
+
+Telegram reference: [Bot API sendPhoto](https://core.telegram.org/bots/api#sendphoto)
+and [getFile](https://core.telegram.org/bots/api#getfile). Telegram may reject
+additional dimensions/aspect ratios even when local validation passes. Its API
+error is surfaced as a failed upload, not a success.
+
+Tests use synthetic PNGs, mock HTTP APIs and temporary Unix sockets/directories;
+no real bot credentials, live agents or Telegram chat are needed. Live validation
+should use a harmless image in each direction after an explicitly coordinated
+bridge restart.

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -101,3 +101,9 @@ func StripH2Envelope(text string) string {
 	}
 	return strings.TrimSpace(text[loc[1]:])
 }
+
+// ImageSender is an optional capability for bridges that can upload a local
+// image with a plain-text caption. Text-only bridges need not implement it.
+type ImageSender interface {
+	SendImage(ctx context.Context, path, caption string) error
+}

--- a/internal/bridge/telegram/images.go
+++ b/internal/bridge/telegram/images.go
@@ -1,0 +1,243 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const maxImageBytes = 10 * 1024 * 1024
+const imageTimeout = 60 * time.Second
+
+// imageFormat bounds decoding work and rejects files that are not JPEG or PNG.
+func imageFormat(data []byte) (string, error) {
+	if len(data) == 0 || len(data) > maxImageBytes {
+		return "", fmt.Errorf("image must be between 1 byte and 10 MiB")
+	}
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil || (format != "jpeg" && format != "png") {
+		return "", fmt.Errorf("image must be JPEG or PNG")
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || int64(cfg.Width) > 40_000_000/int64(cfg.Height) {
+		return "", fmt.Errorf("image dimensions exceed 40 megapixels")
+	}
+	if _, _, err := image.Decode(bytes.NewReader(data)); err != nil {
+		return "", fmt.Errorf("invalid image data")
+	}
+	return format, nil
+}
+
+// imageRequest never includes token-bearing URLs or remote response bodies in
+// errors, and does not follow redirects to a different download endpoint.
+func (t *Telegram) imageRequest(req *http.Request) (*http.Response, error) {
+	client := t.client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Do(req)
+	if err != nil {
+		if req.Context().Err() != nil {
+			return nil, fmt.Errorf("telegram image request: %w", req.Context().Err())
+		}
+		return nil, fmt.Errorf("telegram image request failed")
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("telegram image request: HTTP %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+// SendImage uploads an explicitly selected local image. Caption text is plain
+// text, like Send; a long caption is rejected rather than silently truncated.
+func (t *Telegram) SendImage(ctx context.Context, filename, caption string) error {
+	if utf8.RuneCountInString(caption) > 1024 {
+		return fmt.Errorf("image caption exceeds 1024 characters")
+	}
+	info, err := os.Lstat(filename)
+	if err != nil {
+		return fmt.Errorf("read image: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxImageBytes {
+		return fmt.Errorf("image must be a regular file of at most 10 MiB")
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("open image: %w", err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxImageBytes+1))
+	if err != nil {
+		return fmt.Errorf("read image: %w", err)
+	}
+	format, err := imageFormat(data)
+	if err != nil {
+		return err
+	}
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if err := mw.WriteField("chat_id", strconv.FormatInt(t.ChatID, 10)); err != nil {
+		return err
+	}
+	if err := mw.WriteField("caption", caption); err != nil {
+		return err
+	}
+	part, err := mw.CreateFormFile("photo", "image."+format)
+	if err != nil {
+		return err
+	}
+	if _, err := part.Write(data); err != nil {
+		return err
+	}
+	if err := mw.Close(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, imageTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.apiURL("sendPhoto"), &body)
+	if err != nil {
+		return fmt.Errorf("invalid Telegram endpoint")
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	resp, err := t.imageRequest(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result apiResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+		return fmt.Errorf("telegram sendPhoto: invalid response")
+	}
+	if !result.OK {
+		return fmt.Errorf("telegram sendPhoto: API rejected image")
+	}
+	return nil
+}
+
+type photoSize struct {
+	FileID   string `json:"file_id"`
+	FileSize int64  `json:"file_size,omitempty"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+}
+
+type document struct {
+	FileID   string `json:"file_id"`
+	FileSize int64  `json:"file_size,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+}
+
+func (m *message) imageFile() (string, int64) {
+	var best photoSize
+	for _, p := range m.Photo {
+		if best.FileID == "" || int64(p.Width)*int64(p.Height) > int64(best.Width)*int64(best.Height) {
+			best = p
+		}
+	}
+	if best.FileID != "" {
+		return best.FileID, best.FileSize
+	}
+	if m.Document != nil && (m.Document.MimeType == "image/jpeg" || m.Document.MimeType == "image/png") {
+		return m.Document.FileID, m.Document.FileSize
+	}
+	return "", 0
+}
+
+func (t *Telegram) receiveImage(ctx context.Context, fileID string, size int64) (string, error) {
+	if t.AttachmentDir == "" {
+		return "", fmt.Errorf("image storage is not configured")
+	}
+	if size > maxImageBytes {
+		return "", fmt.Errorf("image exceeds 10 MiB")
+	}
+	ctx, cancel := context.WithTimeout(ctx, imageTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.apiURL("getFile"), strings.NewReader(url.Values{"file_id": {fileID}}.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("invalid Telegram endpoint")
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := t.imageRequest(req)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			FilePath string `json:"file_path"`
+			FileSize int64  `json:"file_size"`
+		} `json:"result"`
+	}
+	err = json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result)
+	resp.Body.Close()
+	if err != nil || !result.OK {
+		return "", fmt.Errorf("telegram getFile: invalid response")
+	}
+	fp := result.Result.FilePath
+	if fp == "" || strings.HasPrefix(fp, "/") || path.Clean(fp) != fp || strings.HasPrefix(fp, "..") || strings.ContainsAny(fp, "\\?#%:\r\n") {
+		return "", fmt.Errorf("telegram getFile: invalid file path")
+	}
+	if result.Result.FileSize > maxImageBytes {
+		return "", fmt.Errorf("image exceeds 10 MiB")
+	}
+	base := t.BaseURL
+	if base == "" {
+		base = "https://api.telegram.org"
+	}
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, base+"/file/bot"+t.Token+"/"+fp, nil)
+	if err != nil {
+		return "", fmt.Errorf("invalid Telegram file endpoint")
+	}
+	resp, err = t.imageRequest(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("telegram image download failed")
+	}
+	format, err := imageFormat(data)
+	if err != nil {
+		return "", err
+	}
+	dir, err := filepath.Abs(t.AttachmentDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve image storage: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create image storage: %w", err)
+	}
+	info, err := os.Lstat(dir)
+	if err != nil || !info.IsDir() || info.Mode().Perm()&0o077 != 0 {
+		return "", fmt.Errorf("image storage must be a private directory")
+	}
+	f, err := os.CreateTemp(dir, "image-*."+format)
+	if err != nil {
+		return "", fmt.Errorf("store image: %w", err)
+	}
+	filename := f.Name()
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(filename)
+		return "", fmt.Errorf("store image: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(filename)
+		return "", fmt.Errorf("store image: %w", err)
+	}
+	return filename, nil
+}

--- a/internal/bridge/telegram/images_test.go
+++ b/internal/bridge/telegram/images_test.go
@@ -1,0 +1,311 @@
+package telegram
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	if err := png.Encode(&b, image.NewRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+
+func TestSendImage(t *testing.T) {
+	data := testPNG(t)
+	filename := filepath.Join(t.TempDir(), "photo.png")
+	if err := os.WriteFile(filename, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/botSECRET/sendPhoto" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Error(err)
+			return
+		}
+		defer r.MultipartForm.RemoveAll()
+		if r.FormValue("chat_id") != "42" || r.FormValue("caption") != "[coder] see this" {
+			t.Errorf("unexpected form %v", r.Form)
+		}
+		f, _, err := r.FormFile("photo")
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer f.Close()
+		got, _ := io.ReadAll(f)
+		if !bytes.Equal(got, data) {
+			t.Error("upload changed image bytes")
+		}
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+	tg := &Telegram{Token: "SECRET", ChatID: 42, BaseURL: srv.URL}
+	if err := tg.SendImage(context.Background(), filename, "[coder] see this"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendImageRejectsInvalidInput(t *testing.T) {
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "valid.png")
+	os.WriteFile(valid, testPNG(t), 0o600)
+	invalid := filepath.Join(dir, "not-image.png")
+	os.WriteFile(invalid, []byte("not an image"), 0o600)
+	oversized := filepath.Join(dir, "large.png")
+	f, err := os.Create(oversized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Truncate(maxImageBytes + 1)
+	f.Close()
+	symlink := filepath.Join(dir, "link.png")
+	if err := os.Symlink(valid, symlink); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct{ name, path, caption string }{
+		{"not-image", invalid, ""}, {"directory", dir, ""}, {"missing", filepath.Join(dir, "missing"), ""}, {"size", oversized, ""}, {"symlink", symlink, ""}, {"caption", valid, strings.Repeat("a", 1025)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tg := &Telegram{}
+			if err := tg.SendImage(context.Background(), tt.path, tt.caption); err == nil {
+				t.Fatal("accepted invalid image")
+			}
+		})
+	}
+}
+
+func TestReceiveImageRoutingAndStorage(t *testing.T) {
+	data := testPNG(t)
+	var fileRequests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/botSECRET/getFile":
+			fileRequests.Add(1)
+			r.ParseForm()
+			if r.FormValue("file_id") != "large" {
+				t.Errorf("wrong file id: %v", r.Form)
+			}
+			fmt.Fprint(w, `{"ok":true,"result":{"file_path":"photos/image.png"}}`)
+		case "/file/botSECRET/photos/image.png":
+			w.Write(data)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+			http.Error(w, "unexpected", 500)
+		}
+	}))
+	defer srv.Close()
+	tg := &Telegram{Token: "SECRET", ChatID: 42, BaseURL: srv.URL, AttachmentDir: filepath.Join(t.TempDir(), "images")}
+	cases := []struct {
+		name, caption, reply, wantAgent string
+		document                        bool
+	}{
+		{"prefix", "coder: inspect this", "", "coder", false},
+		{"reply", "inspect", "[reviewer] previous image", "reviewer", false},
+		{"captionless", "", "", "", false},
+		{"document", "inspect", "", "", true},
+		{"command-caption", "/danger arguments", "", "", false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &message{Chat: chat{ID: 42}, Caption: tt.caption, Photo: []photoSize{{FileID: "small", Width: 1, Height: 1}, {FileID: "large", Width: 2, Height: 2}}}
+			if tt.document {
+				m.Photo = nil
+				m.Document = &document{FileID: "large", MimeType: "image/png"}
+			}
+			if tt.reply != "" {
+				m.ReplyToMessage = &message{Caption: tt.reply}
+			}
+			called := false
+			tg.handleMessage(context.Background(), m, func(agent, body string) {
+				called = true
+				if agent != tt.wantAgent {
+					t.Errorf("agent %q want %q", agent, tt.wantAgent)
+				}
+				marker := "[Image attachment: "
+				start := strings.Index(body, marker)
+				if start < 0 {
+					t.Fatalf("missing image in %q", body)
+				}
+				filename := strings.SplitN(body[start+len(marker):], "]", 2)[0]
+				got, err := os.ReadFile(filename)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, data) {
+					t.Error("stored bytes changed")
+				}
+				info, _ := os.Stat(filename)
+				if info.Mode().Perm() != 0o600 {
+					t.Errorf("mode %v", info.Mode())
+				}
+				if !strings.HasPrefix(filename, tg.AttachmentDir+string(os.PathSeparator)) {
+					t.Error("attachment escaped storage")
+				}
+				if strings.Contains(body, "SECRET") {
+					t.Error("token leaked")
+				}
+			})
+			if !called {
+				t.Fatal("not delivered")
+			}
+		})
+	}
+	if fileRequests.Load() != int32(len(cases)) {
+		t.Errorf("downloads %d", fileRequests.Load())
+	}
+}
+
+func TestReceiveImageRejectsAndNotifies(t *testing.T) {
+	for _, tt := range []struct {
+		name, remotePath             string
+		size                         int64
+		invalid, oversized, redirect bool
+	}{
+		{name: "metadata-size", remotePath: "photos/a.png", size: maxImageBytes + 1},
+		{name: "traversal", remotePath: "../secret"}, {name: "absolute", remotePath: "/etc/passwd"}, {name: "url", remotePath: "https://elsewhere/image.png"},
+		{name: "encoded", remotePath: "photos/%2e%2e/secret"}, {name: "invalid", remotePath: "photos/a.png", invalid: true},
+		{name: "oversized", remotePath: "photos/a.png", oversized: true}, {name: "redirect", remotePath: "photos/a.png", redirect: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var notifications atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "getFile"):
+					json.NewEncoder(w).Encode(map[string]any{"ok": true, "result": map[string]any{"file_path": tt.remotePath, "file_size": tt.size}})
+				case strings.Contains(r.URL.Path, "/file/"):
+					if tt.redirect {
+						http.Redirect(w, r, "https://example.invalid/botSECRET", http.StatusFound)
+					} else if tt.invalid {
+						fmt.Fprint(w, "invalid image")
+					} else if tt.oversized {
+						w.Write(make([]byte, maxImageBytes+1))
+					} else {
+						w.Write(testPNG(t))
+					}
+				case strings.HasSuffix(r.URL.Path, "sendMessage"):
+					notifications.Add(1)
+					r.ParseForm()
+					if strings.Contains(r.FormValue("text"), "SECRET") {
+						t.Error("token leaked")
+					}
+					fmt.Fprint(w, `{"ok":true}`)
+				default:
+					t.Errorf("unexpected path %s", r.URL.Path)
+				}
+			}))
+			defer srv.Close()
+			dir := t.TempDir()
+			tg := &Telegram{Token: "SECRET", ChatID: 42, BaseURL: srv.URL, AttachmentDir: dir}
+			tg.handleMessage(context.Background(), &message{Chat: chat{ID: 42}, Photo: []photoSize{{FileID: "x"}}}, func(string, string) { t.Error("failed image delivered") })
+			if notifications.Load() != 1 {
+				t.Errorf("notifications %d", notifications.Load())
+			}
+			files, _ := os.ReadDir(dir)
+			if len(files) != 0 {
+				t.Error("failed download left files")
+			}
+		})
+	}
+}
+
+func TestImageRequestRedactsTransportError(t *testing.T) {
+	tg := &Telegram{Token: "SECRET", BaseURL: "http://127.0.0.1:1", AttachmentDir: t.TempDir()}
+	_, err := tg.receiveImage(context.Background(), "x", 0)
+	if err == nil || strings.Contains(err.Error(), "SECRET") {
+		t.Fatalf("unsafe error %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = tg.receiveImage(ctx, "x", 0)
+	if err == nil {
+		t.Fatal("ignored cancellation")
+	}
+}
+
+func TestImageChatAuthorization(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests.Add(1); http.Error(w, "must not download", 500) }))
+	defer srv.Close()
+	tg := &Telegram{ChatID: 42, AttachmentDir: t.TempDir(), BaseURL: srv.URL}
+	tg.handleMessage(context.Background(), &message{Chat: chat{ID: 99}, Photo: []photoSize{{FileID: "x"}}}, func(string, string) { t.Fatal("unauthorized delivery") })
+	if requests.Load() != 0 {
+		t.Fatal("unauthorized image triggered network activity")
+	}
+}
+
+func TestPollImage(t *testing.T) {
+	data := testPNG(t)
+	var polled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/botTOKEN/getUpdates":
+			if !polled.Swap(true) {
+				fmt.Fprint(w, `{"ok":true,"result":[{"update_id":1,"message":{"chat":{"id":42},"caption":"coder: inspect","photo":[{"file_id":"img","width":2,"height":2}]}}]}`)
+			} else {
+				<-r.Context().Done()
+			}
+		case "/botTOKEN/getFile":
+			fmt.Fprint(w, `{"ok":true,"result":{"file_path":"photos/a.png"}}`)
+		case "/file/botTOKEN/photos/a.png":
+			w.Write(data)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	tg := &Telegram{Token: "TOKEN", ChatID: 42, BaseURL: srv.URL, AttachmentDir: filepath.Join(t.TempDir(), "images")}
+	got := make(chan string, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := tg.Start(ctx, func(agent, body string) {
+		if agent != "coder" {
+			t.Errorf("agent %q", agent)
+		}
+		got <- body
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer tg.Stop()
+	select {
+	case body := <-got:
+		if !strings.Contains(body, "[Image attachment:") {
+			t.Fatalf("missing image: %q", body)
+		}
+	case <-ctx.Done():
+		t.Fatal("no image delivered")
+	}
+}
+
+func TestImageStorageAndDecodeFailures(t *testing.T) {
+	data := testPNG(t)
+	if _, err := imageFormat(data[:len(data)/2]); err == nil {
+		t.Fatal("accepted truncated PNG")
+	}
+	tg := &Telegram{AttachmentDir: t.TempDir(), BaseURL: "http://127.0.0.1:1"}
+	if _, err := tg.receiveImage(context.Background(), "id", maxImageBytes+1); err == nil || !strings.Contains(err.Error(), "10 MiB") {
+		t.Fatalf("declared size was not rejected: %v", err)
+	}
+	tg.AttachmentDir = ""
+	if _, err := tg.receiveImage(context.Background(), "id", 0); err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("missing storage accepted: %v", err)
+	}
+}

--- a/internal/bridge/telegram/telegram.go
+++ b/internal/bridge/telegram/telegram.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,6 +36,9 @@ type Telegram struct {
 	Token           string
 	ChatID          int64
 	AllowedCommands []string
+
+	// AttachmentDir stores received images privately; empty disables downloads.
+	AttachmentDir string
 
 	// BaseURL overrides the Telegram API base for testing.
 	// If empty, defaults to "https://api.telegram.org".
@@ -76,10 +80,15 @@ func (t *Telegram) Send(ctx context.Context, text string) error {
 }
 
 func (t *Telegram) sendChunk(ctx context.Context, text string) error {
-	resp, err := t.client.PostForm(t.apiURL("sendMessage"), url.Values{
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.apiURL("sendMessage"), strings.NewReader(url.Values{
 		"chat_id": {strconv.FormatInt(t.ChatID, 10)},
 		"text":    {text},
-	})
+	}.Encode()))
+	if err != nil {
+		return fmt.Errorf("telegram send: invalid endpoint")
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := t.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram send: %w", err)
 	}
@@ -157,19 +166,7 @@ func (t *Telegram) poll(ctx context.Context, handler bridge.InboundHandler) {
 			if u.Message == nil || u.Message.Chat.ID != t.ChatID {
 				continue
 			}
-			// Check for slash commands before agent routing.
-			cmd, args := bridge.ParseSlashCommand(u.Message.Text, t.AllowedCommands)
-			if cmd != "" {
-				log.Printf("bridge: telegram: executing command /%s %s", cmd, args)
-				go t.execAndReply(ctx, cmd, args)
-				continue
-			}
-			agent, body := bridge.ParseAgentPrefix(u.Message.Text)
-			// If no explicit prefix, check reply-to message for agent tag.
-			if agent == "" && u.Message.ReplyToMessage != nil {
-				agent = bridge.ParseAgentTag(u.Message.ReplyToMessage.Text)
-			}
-			handler(agent, body)
+			t.handleMessage(ctx, u.Message, handler)
 		}
 	}
 }
@@ -250,11 +247,61 @@ type update struct {
 }
 
 type message struct {
-	Text           string   `json:"text"`
-	Chat           chat     `json:"chat"`
-	ReplyToMessage *message `json:"reply_to_message,omitempty"`
+	Text           string      `json:"text"`
+	Caption        string      `json:"caption,omitempty"`
+	Photo          []photoSize `json:"photo,omitempty"`
+	Document       *document   `json:"document,omitempty"`
+	Chat           chat        `json:"chat"`
+	ReplyToMessage *message    `json:"reply_to_message,omitempty"`
 }
 
 type chat struct {
 	ID int64 `json:"id"`
+}
+
+// handleMessage preserves text routing for image captions without executing
+// captions as slash commands. Only messages from the configured chat reach it.
+func (t *Telegram) handleMessage(ctx context.Context, m *message, handler bridge.InboundHandler) {
+	if m.Chat.ID != t.ChatID {
+		return
+	}
+	fileID, size := m.imageFile()
+	text := m.Text
+	if fileID != "" {
+		text = m.Caption
+	}
+	if fileID == "" {
+		cmd, args := bridge.ParseSlashCommand(text, t.AllowedCommands)
+		if cmd != "" {
+			log.Printf("bridge: telegram: executing command /%s %s", cmd, args)
+			go t.execAndReply(ctx, cmd, args)
+			return
+		}
+	}
+	agent, body := bridge.ParseAgentPrefix(text)
+	if agent == "" && m.ReplyToMessage != nil {
+		reply := m.ReplyToMessage.Text
+		if reply == "" {
+			reply = m.ReplyToMessage.Caption
+		}
+		agent = bridge.ParseAgentTag(reply)
+	}
+	if fileID != "" {
+		filename, err := t.receiveImage(ctx, fileID, size)
+		if err != nil {
+			// Explicit failure instead of silently delivering the caption alone.
+			log.Printf("bridge: telegram: receive image: %v", err)
+			notifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			if sendErr := t.Send(notifyCtx, "Unable to receive image: "+err.Error()); sendErr != nil {
+				log.Printf("bridge: telegram: image error notification failed")
+			}
+			return
+		}
+		body += fmt.Sprintf("\n\n[Image attachment: %s]\nOpen this local image with your image-viewing tool to inspect it.", filename)
+	}
+	if body == "" {
+		return
+	}
+	handler(agent, body)
 }

--- a/internal/bridgeservice/factory.go
+++ b/internal/bridgeservice/factory.go
@@ -8,11 +8,14 @@ import (
 )
 
 // FromConfig instantiates bridge instances from a user's bridge configuration.
-func FromConfig(cfg *config.BridgesConfig) []bridge.Bridge {
+// attachmentDir is the private local directory for incoming images; an empty
+// path disables image downloads. It is created lazily on the first image.
+func FromConfig(cfg *config.BridgesConfig, attachmentDir string) []bridge.Bridge {
 	var bridges []bridge.Bridge
 	if cfg.Telegram != nil {
 		bridges = append(bridges, &telegram.Telegram{
 			Token:           cfg.Telegram.BotToken,
+			AttachmentDir:   attachmentDir,
 			ChatID:          cfg.Telegram.ChatID,
 			AllowedCommands: cfg.Telegram.AllowedCommands,
 		})

--- a/internal/bridgeservice/factory_test.go
+++ b/internal/bridgeservice/factory_test.go
@@ -19,7 +19,7 @@ func TestFromConfig_AllBridges(t *testing.T) {
 		},
 	}
 
-	bridges := FromConfig(cfg)
+	bridges := FromConfig(cfg, t.TempDir())
 	if len(bridges) != 2 {
 		t.Fatalf("expected 2 bridges, got %d", len(bridges))
 	}
@@ -52,7 +52,7 @@ func TestFromConfig_TelegramOnly(t *testing.T) {
 		},
 	}
 
-	bridges := FromConfig(cfg)
+	bridges := FromConfig(cfg, t.TempDir())
 	if len(bridges) != 1 {
 		t.Fatalf("expected 1 bridge, got %d", len(bridges))
 	}
@@ -68,7 +68,7 @@ func TestFromConfig_MacOSNotifyDisabled(t *testing.T) {
 		},
 	}
 
-	bridges := FromConfig(cfg)
+	bridges := FromConfig(cfg, t.TempDir())
 	if len(bridges) != 0 {
 		t.Fatalf("expected 0 bridges when disabled, got %d", len(bridges))
 	}
@@ -83,7 +83,7 @@ func TestFromConfig_AllowedCommandsPropagation(t *testing.T) {
 		},
 	}
 
-	bridges := FromConfig(cfg)
+	bridges := FromConfig(cfg, t.TempDir())
 	if len(bridges) != 1 {
 		t.Fatalf("expected 1 bridge, got %d", len(bridges))
 	}
@@ -100,7 +100,7 @@ func TestFromConfig_AllowedCommandsPropagation(t *testing.T) {
 func TestFromConfig_Empty(t *testing.T) {
 	cfg := &config.BridgesConfig{}
 
-	bridges := FromConfig(cfg)
+	bridges := FromConfig(cfg, t.TempDir())
 	if len(bridges) != 0 {
 		t.Fatalf("expected 0 bridges, got %d", len(bridges))
 	}

--- a/internal/bridgeservice/images_test.go
+++ b/internal/bridgeservice/images_test.go
@@ -1,0 +1,215 @@
+package bridgeservice
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"h2/internal/bridge"
+	"h2/internal/bridge/telegram"
+	"h2/internal/session/message"
+	"h2/internal/socketdir"
+)
+
+type mockImageSender struct {
+	mockSender
+	path, caption string
+	fail          bool
+}
+
+func (m *mockImageSender) SendImage(_ context.Context, path, caption string) error {
+	m.path = path
+	m.caption = caption
+	if m.fail {
+		return errors.New("upload failed")
+	}
+	return nil
+}
+
+func TestSendOutboundImage(t *testing.T) {
+	img := &mockImageSender{mockSender: mockSender{name: "image"}}
+	text := &mockSender{name: "text-only"}
+	s := New([]bridge.Bridge{img, text}, "test", "concierge", "", t.TempDir(), nil)
+	if err := s.sendOutboundImage("coder", "caption", "/tmp/image.png"); err != nil {
+		t.Fatal(err)
+	}
+	if img.path != "/tmp/image.png" || img.caption != "[coder] caption" {
+		t.Fatalf("wrong image delivery: %+v", img)
+	}
+	if len(text.Messages()) != 0 {
+		t.Fatal("silently sent caption without image to text-only bridge")
+	}
+	if err := s.sendOutboundImage("concierge", "plain", "/tmp/image.png"); err != nil {
+		t.Fatal(err)
+	}
+	if img.caption != "plain" {
+		t.Fatalf("concierge caption: %q", img.caption)
+	}
+	img.fail = true
+	if err := s.sendOutboundImage("coder", "caption", "/tmp/image.png"); err == nil {
+		t.Fatal("upload failure swallowed")
+	}
+	s = New([]bridge.Bridge{text}, "test", "", "", t.TempDir(), nil)
+	if err := s.sendOutboundImage("coder", "caption", "/tmp/image.png"); err == nil {
+		t.Fatal("text-only bridge accepted image")
+	}
+}
+
+func TestSendImageSocket(t *testing.T) {
+	for _, filename := range []string{"/tmp/image.png", ""} {
+		t.Run(filename, func(t *testing.T) {
+			img := &mockImageSender{mockSender: mockSender{name: "image"}}
+			s := New([]bridge.Bridge{img}, "test", "", "", t.TempDir(), nil)
+			client, server := net.Pipe()
+			defer client.Close()
+			go s.handleConn(server)
+			if err := message.SendRequest(client, &message.Request{Type: "send-image", From: "coder", ImagePath: filename}); err != nil {
+				t.Fatal(err)
+			}
+			resp, err := message.ReadResponse(client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.OK != (filename != "") {
+				t.Fatalf("unexpected response %+v", resp)
+			}
+			if filename != "" && img.path != filename {
+				t.Error("image path lost on wire")
+			}
+		})
+	}
+}
+
+// Exercise the actual Telegram receiver and sender with the bridge socket and
+// agent message protocol; only the remote Bot API and the agent are test doubles.
+func TestTelegramImageRoundTrip(t *testing.T) {
+	var data bytes.Buffer
+	if err := png.Encode(&data, image.NewRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+	var polled atomic.Bool
+	uploaded := make(chan string, 1)
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/botTEST/getUpdates":
+			if !polled.Swap(true) {
+				fmt.Fprint(w, `{"ok":true,"result":[{"update_id":1,"message":{"chat":{"id":42},"caption":"test-agent: look","photo":[{"file_id":"photo","width":2,"height":2}]}}]}`)
+			} else {
+				<-r.Context().Done()
+			}
+		case "/botTEST/getFile":
+			fmt.Fprint(w, `{"ok":true,"result":{"file_path":"photos/a.png"}}`)
+		case "/file/botTEST/photos/a.png":
+			w.Write(data.Bytes())
+		case "/botTEST/sendPhoto":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Error(err)
+				http.Error(w, "bad multipart", http.StatusBadRequest)
+				return
+			}
+			defer r.MultipartForm.RemoveAll()
+			f, _, err := r.FormFile("photo")
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer f.Close()
+			got, err := io.ReadAll(f)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !bytes.Equal(got, data.Bytes()) {
+				t.Error("round trip changed image bytes")
+			}
+			uploaded <- r.FormValue("caption")
+			fmt.Fprint(w, `{"ok":true}`)
+		default:
+			t.Errorf("unexpected API request %s", r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer api.Close()
+	dir := t.TempDir()
+	agentSocket := filepath.Join(dir, socketdir.Format(socketdir.TypeAgent, "test-agent"))
+	ln, err := net.Listen("unix", agentSocket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	received := make(chan *message.Request, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		req, err := message.ReadRequest(conn)
+		if err != nil {
+			return
+		}
+		received <- req
+		message.SendResponse(conn, &message.Response{OK: true})
+	}()
+	tg := &telegram.Telegram{Token: "TEST", ChatID: 42, BaseURL: api.URL, AttachmentDir: filepath.Join(dir, "attachments")}
+	s := New([]bridge.Bridge{tg}, "telegram", "test-agent", "", dir, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := tg.Start(ctx, s.handleInbound); err != nil {
+		t.Fatal(err)
+	}
+	defer tg.Stop()
+	var filename string
+	select {
+	case req := <-received:
+		if req.Type != "send" || req.From != "telegram" || !strings.HasPrefix(req.Body, "look") {
+			t.Fatalf("bad inbound request %+v", req)
+		}
+		marker := "[Image attachment: "
+		start := strings.Index(req.Body, marker)
+		if start < 0 {
+			t.Fatal("attachment missing from delivered message")
+		}
+		filename = strings.SplitN(req.Body[start+len(marker):], "]", 2)[0]
+		got, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, data.Bytes()) {
+			t.Fatal("agent cannot read the received image")
+		}
+	case <-ctx.Done():
+		t.Fatal("no agent delivery")
+	}
+	client, server := net.Pipe()
+	defer client.Close()
+	go s.handleConn(server)
+	if err := message.SendRequest(client, &message.Request{Type: "send-image", From: "test-agent", ImagePath: filename, Body: "inspected"}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := message.ReadResponse(client)
+	if err != nil || !resp.OK {
+		t.Fatalf("outbound failed: %+v, %v", resp, err)
+	}
+	select {
+	case caption := <-uploaded:
+		if caption != "inspected" {
+			t.Fatalf("caption %q", caption)
+		}
+	case <-ctx.Done():
+		t.Fatal("no upload")
+	}
+}

--- a/internal/bridgeservice/images_test.go
+++ b/internal/bridgeservice/images_test.go
@@ -143,7 +143,7 @@ func TestTelegramImageRoundTrip(t *testing.T) {
 		}
 	}))
 	defer api.Close()
-	dir := t.TempDir()
+	dir := shortTempDir(t)
 	agentSocket := filepath.Join(dir, socketdir.Format(socketdir.TypeAgent, "test-agent"))
 	ln, err := net.Listen("unix", agentSocket)
 	if err != nil {

--- a/internal/bridgeservice/service.go
+++ b/internal/bridgeservice/service.go
@@ -162,8 +162,12 @@ func (s *Service) handleConn(conn net.Conn) {
 	}
 
 	switch req.Type {
-	case "send":
-		if err := s.sendOutbound(req.From, req.Body); err != nil {
+	case "send", "send-image":
+		if (req.Type == "send-image") != (req.ImagePath != "") {
+			message.SendResponse(conn, &message.Response{Error: "send-image requires an image path; send accepts text only"})
+			return
+		}
+		if err := s.sendOutboundImage(req.From, req.Body, req.ImagePath); err != nil {
 			message.SendResponse(conn, &message.Response{Error: err.Error()})
 		} else {
 			message.SendResponse(conn, &message.Response{OK: true})
@@ -184,7 +188,7 @@ func (s *Service) handleConn(conn net.Conn) {
 		s.cancel()
 	default:
 		message.SendResponse(conn, &message.Response{
-			Error: "bridge only handles 'send', 'status', 'stop', 'set-concierge', and 'remove-concierge' requests",
+			Error: "bridge only handles 'send', 'send-image', 'status', 'stop', 'set-concierge', and 'remove-concierge' requests",
 		})
 	}
 }
@@ -302,6 +306,10 @@ func (s *Service) handleRemoveConcierge() *message.Response {
 // replies can be routed back to the correct agent.
 // Returns an error if any bridge fails to deliver the message.
 func (s *Service) sendOutbound(from, body string) error {
+	return s.sendOutboundImage(from, body, "")
+}
+
+func (s *Service) sendOutboundImage(from, body, imagePath string) error {
 	s.mu.Lock()
 	s.lastSender = from
 	s.messagesSent++
@@ -317,13 +325,26 @@ func (s *Service) sendOutbound(from, body string) error {
 
 	ctx := context.Background()
 	var errs []string
+	sentImage := false
 	for _, b := range s.bridges {
+		if imagePath != "" {
+			if sender, ok := b.(bridge.ImageSender); ok {
+				sentImage = true
+				if err := sender.SendImage(ctx, imagePath, tagged); err != nil {
+					errs = append(errs, fmt.Sprintf("%s: %v", b.Name(), err))
+				}
+			}
+			continue
+		}
 		if sender, ok := b.(bridge.Sender); ok {
 			if err := sender.Send(ctx, tagged); err != nil {
 				log.Printf("bridge: send via %s: %v", b.Name(), err)
 				errs = append(errs, fmt.Sprintf("%s: %v", b.Name(), err))
 			}
 		}
+	}
+	if imagePath != "" && !sentImage {
+		return fmt.Errorf("bridge does not support images")
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("send failed: %s", strings.Join(errs, "; "))

--- a/internal/cmd/bridge_daemon.go
+++ b/internal/cmd/bridge_daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func newBridgeDaemonCmd() *cobra.Command {
 				return err
 			}
 
-			bridges := bridgeservice.FromConfig(bc)
+			bridges := bridgeservice.FromConfig(bc, filepath.Join(config.ConfigDir(), "attachments", bridgeName))
 			if len(bridges) == 0 {
 				return fmt.Errorf("no bridges configured for %q", bridgeName)
 			}

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -16,23 +17,35 @@ import (
 func newSendCmd() *cobra.Command {
 	var priority string
 	var file string
+	var imagePath string
 	var allowSelf bool
 	var raw bool
 	var expectsResponse bool
 	var respondsTo string
 
 	cmd := &cobra.Command{
-		Use:   "send [<name>] [--priority=normal] [--file=path] [--raw] [--expects-response] [--closes=<id>] [message...]",
+		Use:   "send [<name>] [--priority=normal] [--file=path] [--image=path] [--raw] [--expects-response] [--closes=<id>] [message...]",
 		Short: "Send a message to an agent",
 		Long: `Send a message to a running agent. The message body can be provided as arguments or read from a file.
+With --image, upload a local JPEG/PNG to a bridge; the optional body is its caption.
 With --raw, the body is sent directly to the agent's PTY without the header prefix.
 With --expects-response, a reminder trigger is registered on the recipient that fires at idle.
 With --closes <id>, the reminder trigger is removed from your own daemon (and optionally a response is sent).`,
 		Args: cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if imagePath != "" {
+				if raw || expectsResponse {
+					return fmt.Errorf("--image cannot be combined with --raw or --expects-response")
+				}
+				var err error
+				imagePath, err = filepath.Abs(imagePath)
+				if err != nil {
+					return fmt.Errorf("resolve image path: %w", err)
+				}
+			}
 			// --closes mode: target and body are both optional.
 			if respondsTo != "" {
-				return handleCloses(respondsTo, args, file, priority, allowSelf)
+				return handleCloses(respondsTo, args, file, priority, allowSelf, imagePath)
 			}
 
 			// Normal send or --expects-response: target is required.
@@ -50,7 +63,7 @@ With --closes <id>, the reminder trigger is removed from your own daemon (and op
 				body = string(data)
 			} else if len(args) > 1 {
 				body = cleanLLMEscapes(strings.Join(args[1:], " "))
-			} else {
+			} else if imagePath == "" {
 				return fmt.Errorf("message body is required (provide as arguments or --file)")
 			}
 
@@ -84,6 +97,9 @@ With --closes <id>, the reminder trigger is removed from your own daemon (and op
 				removeTriggerBestEffort(name, triggerID)
 				return agentConnError(name, findErr)
 			}
+			if err := checkImageTarget(sockPath, imagePath); err != nil {
+				return err
+			}
 			conn, err := net.Dial("unix", sockPath)
 			if err != nil {
 				removeTriggerBestEffort(name, triggerID)
@@ -96,6 +112,10 @@ With --closes <id>, the reminder trigger is removed from your own daemon (and op
 				From:     from,
 				Body:     body,
 				Raw:      raw,
+			}
+			if imagePath != "" {
+				req.Type = "send-image"
+				req.ImagePath = imagePath
 			}
 			if expectsResponse {
 				req.ExpectsResponse = true
@@ -130,6 +150,7 @@ With --closes <id>, the reminder trigger is removed from your own daemon (and op
 	}
 
 	cmd.Flags().StringVar(&priority, "priority", "normal", "Message priority (interrupt|normal|idle-first|idle)")
+	cmd.Flags().StringVar(&imagePath, "image", "", "Upload a local JPEG/PNG to an image-capable bridge; body is the optional caption")
 	cmd.Flags().StringVar(&file, "file", "", "Read message body from file")
 	cmd.Flags().BoolVar(&allowSelf, "allow-self", false, "Allow sending a message to yourself")
 	cmd.Flags().BoolVar(&raw, "raw", false, "Send body directly to PTY without header prefix (useful for permission prompts)")
@@ -208,7 +229,7 @@ func removeTriggerBestEffort(agentName, triggerID string) {
 
 // handleCloses handles the --responds-to flow: optionally send a response,
 // then remove the trigger from own daemon.
-func handleCloses(triggerID string, args []string, file, priority string, allowSelf bool) error {
+func handleCloses(triggerID string, args []string, file, priority string, allowSelf bool, imagePath string) error {
 	var name, body string
 
 	if file != "" {
@@ -225,18 +246,21 @@ func handleCloses(triggerID string, args []string, file, priority string, allowS
 		name = args[0]
 		body = cleanLLMEscapes(strings.Join(args[1:], " "))
 	} else if len(args) == 1 {
+		if imagePath != "" {
+			name = args[0]
+		}
 		// Could be just a target name with no body — treat as close-only.
 		// The target is ignored for close-only, but we accept it.
 	}
 	// len(args) == 0: close-only, no target, no body.
 
 	// If body is present, target must be present.
-	if body != "" && name == "" {
+	if (body != "" || imagePath != "") && name == "" {
 		return fmt.Errorf("target agent name is required when sending a response body")
 	}
 
 	// Send the response message first (if body present).
-	if body != "" {
+	if body != "" || imagePath != "" {
 		if priority == "" {
 			priority = "normal"
 		}
@@ -252,17 +276,25 @@ func handleCloses(triggerID string, args []string, file, priority string, allowS
 		if findErr != nil {
 			return agentConnError(name, findErr)
 		}
+		if err := checkImageTarget(sockPath, imagePath); err != nil {
+			return err
+		}
 		conn, err := net.Dial("unix", sockPath)
 		if err != nil {
 			return agentConnError(name, err)
 		}
 		defer conn.Close()
 
+		requestType := "send"
+		if imagePath != "" {
+			requestType = "send-image"
+		}
 		if err := message.SendRequest(conn, &message.Request{
-			Type:     "send",
-			Priority: priority,
-			From:     from,
-			Body:     body,
+			Type:      requestType,
+			ImagePath: imagePath,
+			Priority:  priority,
+			From:      from,
+			Body:      body,
 		}); err != nil {
 			return fmt.Errorf("send request: %w", err)
 		}
@@ -352,4 +384,15 @@ func stripBackslashPunctuation(s string) string {
 		b.WriteByte(s[i])
 	}
 	return b.String()
+}
+
+func checkImageTarget(sockPath, imagePath string) error {
+	if imagePath == "" {
+		return nil
+	}
+	entry, ok := socketdir.Parse(filepath.Base(sockPath))
+	if !ok || entry.Type != socketdir.TypeBridge {
+		return fmt.Errorf("--image requires a bridge target")
+	}
+	return nil
 }

--- a/internal/cmd/send_image_test.go
+++ b/internal/cmd/send_image_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"h2/internal/config"
+	"h2/internal/session/message"
+	"h2/internal/socketdir"
+)
+
+func TestSendImageCLI(t *testing.T) {
+	for _, closeID := range []string{"", "done"} {
+		t.Run(closeID, func(t *testing.T) {
+			home := setupFakeHome(t)
+			t.Setenv("H2_DIR", filepath.Join(home, ".h2"))
+			config.ResetResolveCache()
+			socketdir.ResetDirCache()
+			t.Cleanup(func() { config.ResetResolveCache(); socketdir.ResetDirCache() })
+			dir := socketdir.Dir()
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			listener, err := net.Listen("unix", filepath.Join(dir, socketdir.Format(socketdir.TypeBridge, "test")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			requests := make(chan *message.Request, 1)
+			go func() {
+				conn, err := listener.Accept()
+				if err != nil {
+					return
+				}
+				defer conn.Close()
+				req, err := message.ReadRequest(conn)
+				if err != nil {
+					return
+				}
+				requests <- req
+				message.SendResponse(conn, &message.Response{OK: true})
+			}()
+			cmd := newSendCmd()
+			args := []string{"--image", "example.png", "test"}
+			if closeID != "" {
+				args = append(args, "--closes", closeID)
+			}
+			cmd.SetArgs(args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case req := <-requests:
+				expected, _ := filepath.Abs("example.png")
+				if req.Type != "send-image" || req.ImagePath != expected || req.Body != "" {
+					t.Fatalf("bad request %+v", req)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("no image request")
+			}
+		})
+	}
+}
+
+func TestSendImageValidation(t *testing.T) {
+	for _, flag := range []string{"--raw", "--expects-response"} {
+		t.Run(flag, func(t *testing.T) {
+			cmd := newSendCmd()
+			cmd.SetArgs([]string{"--image", "a.png", flag, "test"})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+				t.Fatalf("unexpected error %v", err)
+			}
+		})
+	}
+	if err := checkImageTarget("/tmp/agent.test.sock", "/tmp/image.png"); err == nil {
+		t.Fatal("agent image target accepted")
+	}
+	if err := checkImageTarget("/tmp/bridge.test.sock", "/tmp/image.png"); err != nil {
+		t.Fatal(err)
+	}
+	if err := handleCloses("done", nil, "", "normal", false, "/tmp/image.png"); err == nil {
+		t.Fatal("image close without target accepted")
+	}
+}

--- a/internal/session/message/protocol.go
+++ b/internal/session/message/protocol.go
@@ -11,9 +11,10 @@ import (
 
 // Request is the JSON request sent over the Unix socket.
 type Request struct {
-	Type string `json:"type"` // "send", "attach", "show", "status", "hook_event", "stop", "relaunch", "trigger_add", "trigger_list", "trigger_remove", "schedule_add", "schedule_list", "schedule_remove"
+	Type string `json:"type"` // "send", "send-image", "attach", "show", "status", "hook_event", "stop", "relaunch", "trigger_add", "trigger_list", "trigger_remove", "schedule_add", "schedule_list", "schedule_remove"
 
 	// send fields
+	ImagePath       string `json:"image_path,omitempty"` // explicit local image for bridge send-image requests
 	Priority        string `json:"priority,omitempty"`
 	From            string `json:"from,omitempty"`
 	Body            string `json:"body,omitempty"`


### PR DESCRIPTION

<img width="1153" height="1364" alt="image" src="https://github.com/user-attachments/assets/3fe03e60-a48d-42f3-a710-4bdebf06b8e1" />


## Summary

Add image support to the existing Telegram bridge, without a separate service or harness-specific prompt protocol.

- Receive Telegram photos and JPEG/PNG documents. Save validated image bytes in a private `$H2_DIR/attachments/<bridge-name>/` directory, then deliver the caption and local image path through the existing agent-message route.
- Add `h2 send <bridge> --image ./image.png [caption]`, including `--closes` support. Image uploads use an optional `bridge.ImageSender` capability; text-only bridges are unchanged.
- Preserve caption prefixes and reply-to-agent routing. Image captions are not executed as slash commands.
- Use a distinct `send-image` socket operation so an older bridge rejects the request instead of silently discarding the image.

## Safety and scope

- Configured-chat authorization before downloading, bounded metadata/downloads, JPEG/PNG decoding and dimension checks, private files with generated names, no remote filenames used locally.
- Image HTTP requests have deadlines, reject redirects, and omit token-bearing URLs/remote response bodies from errors. Error notifications respect cancellation.
- Upload only explicitly selected regular local files; do not interpret paths or URLs in message text as upload instructions.
- Inbound images are **local file references**, not native multimodal prompt injection. Agents need an image-viewing tool and access to the attachment directory.
- One image per send; photo albums arrive as separate Telegram updates. No GIF/sticker/video support, automatic retention cleanup, or automatic upload retry in this change. Those limitations are documented.
- No production daemon restart or live bot credentials were used for validation.

## Verification

- `make check` — pass (gofmt, go vet, staticcheck).
- `make test` — pass.
- `make test-external` — pass with inherited `H2_*` session variables removed and temporary h2 roots. An initial run inherited `H2_POD=ops`, which filtered pod-list fixtures; rerunning in the isolated environment passed.
- `go test -race ./internal/bridge/telegram ./internal/bridgeservice -count=1` — pass.
- `make build` — pass.

New tests cover multipart upload, captionless sends and `--closes`, routing, file validation, chat authorization, size/path/redirect errors, error redaction, and socket capability handling. A synthetic-image integration test goes through Bot API polling → local attachment → agent socket → bridge socket → Bot API upload. The HTTP API and agent are test doubles; the Telegram implementation and bridge service are real.

The broader CLI race build was stopped while instrumenting the large treesitter Bash grammar to avoid exhausting the development host's memory; the CLI is covered by the normal full and external suites, while the transport packages passed race testing.

Usage and retention/privacy details: [`docs/telegram-images.md`](docs/telegram-images.md).
