### PR TITLE
feat(telegram): render restrained emphasis with safe text entities

### DIFF
--- a/docs/telegram-formatting.md
+++ b/docs/telegram-formatting.md
@@ -1,0 +1,45 @@
+# Telegram text formatting
+
+Outgoing Telegram text messages recognize a deliberately small Markdown-like
+subset, without changing stored message bodies or the CLI interface:
+
+- `**important text**` becomes bold (also useful for headings).
+- Single backticks mark inline code, such as commands and paths.
+- Triple-backtick fenced blocks become copyable preformatted code. An optional
+  language label such as `bash` is passed to Telegram.
+- Paragraph spacing, bullets and numbered steps stay as written.
+
+This is not a full Markdown parser: headings using `#`, links, tables, nested
+emphasis, italic and arbitrary HTML are not interpreted. Use explicit `**bold**`
+headings. Unsupported delimiter runs and unclosed blocks remain literal. Code
+contents are never interpreted as emphasis. Plain text colors and fonts follow
+Telegram's client/theme, not terminal ANSI colors. Image captions are unchanged.
+
+The bridge sends text plus Telegram `entities`, not `parse_mode`. This avoids
+HTML/Markdown escaping failures for shell operators, paths and other literal
+text. Entity offsets use UTF-16 units, including emoji. Long messages are split
+at UTF-8 boundaries within a conservative 4096 UTF-16-unit budget, preferably
+at newlines. Spanning entities are clipped and rebased per page. The existing
+three-page cap remains; its truncation notice is outside formatting entities.
+
+For literal markup, put it inside a code span/block. A backslash before an inline
+opening marker prevents formatting; that backslash is retained. Single-line,
+non-nested bold/code and unindented triple-backtick blocks are the supported
+syntax; this first increment intentionally does not try to render all Markdown.
+
+Example message body:
+
+~~~~text
+**Status**
+• Bridgen kjører.
+• **Ingen agentrestart nødvendig.**
+
+**Sjekk**
+Kjør `h2o list --all`:
+
+```bash
+h2o list --all
+```
+~~~~
+
+Telegram API reference: https://core.telegram.org/bots/api#messageentity

--- a/internal/bridge/telegram/formatting.go
+++ b/internal/bridge/telegram/formatting.go
@@ -1,0 +1,169 @@
+package telegram
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// Telegram entity offsets and lengths are UTF-16 code units, not bytes or runes.
+// Explicit entities keep arbitrary text (HTML, shell operators, underscores)
+// literal without Telegram parse_mode escaping rules.
+type textEntity struct {
+	Type     string `json:"type"`
+	Offset   int    `json:"offset"`
+	Length   int    `json:"length"`
+	Language string `json:"language,omitempty"`
+}
+
+type formattedMessage struct {
+	Text     string
+	Entities []textEntity
+}
+
+// This deliberately small syntax is not a full Markdown parser. Unsupported or
+// unclosed markup stays literal. Code contents are never parsed for emphasis.
+var (
+	fencedCode  = regexp.MustCompile("^```([a-zA-Z0-9_+-]*)[ \\t]*\\r?\\n$")
+	inlineStyle = regexp.MustCompile("`([^`\\n]+)`|\\*\\*([^*`\\n]+)\\*\\*")
+)
+
+func utf16Len(s string) int {
+	n := 0
+	for _, r := range s {
+		n++
+		if r > 0xffff {
+			n++
+		}
+	}
+	return n
+}
+
+func formatMessage(source string) formattedMessage {
+	var b strings.Builder
+	var entities []textEntity
+	offset := 0
+	write := func(s string) { b.WriteString(s); offset += utf16Len(s) }
+	styled := func(s, kind, language string) {
+		length := utf16Len(s)
+		if length > 0 {
+			entities = append(entities, textEntity{Type: kind, Offset: offset, Length: length, Language: language})
+		}
+		write(s)
+	}
+	inline := func(s string) {
+		start := 0
+		for _, m := range inlineStyle.FindAllStringSubmatchIndex(s, -1) {
+			delimiter := s[m[0]]
+			if (m[0] > 0 && s[m[0]-1] == delimiter) || (m[1] < len(s) && s[m[1]] == delimiter) {
+				continue
+			}
+			slashes := 0
+			for j := m[0] - 1; j >= 0 && s[j] == '\\'; j-- {
+				slashes++
+			}
+			if slashes%2 != 0 {
+				continue
+			}
+			write(s[start:m[0]])
+			if m[2] >= 0 {
+				styled(s[m[2]:m[3]], "code", "")
+			} else {
+				styled(s[m[4]:m[5]], "bold", "")
+			}
+			start = m[1]
+		}
+		write(s[start:])
+	}
+	lines := strings.SplitAfter(source, "\n")
+	for i := 0; i < len(lines); i++ {
+		match := fencedCode.FindStringSubmatch(lines[i])
+		if match == nil {
+			inline(lines[i])
+			continue
+		}
+		end := i + 1
+		for end < len(lines) && strings.TrimRight(lines[end], " \t\r\n") != "```" {
+			end++
+		}
+		if end == len(lines) {
+			// An unfinished block must not reinterpret shell syntax as emphasis.
+			write(strings.Join(lines[i:], ""))
+			break
+		}
+		body := strings.Join(lines[i+1:end], "")
+		if strings.TrimSpace(body) == "" {
+			write(strings.Join(lines[i:end+1], ""))
+		} else {
+			styled(body, "pre", match[1])
+		}
+		i = end
+	}
+	return formattedMessage{Text: b.String(), Entities: entities}
+}
+
+// splitFormatted preserves UTF-8 boundaries and clips/rebases entities on each
+// page, including when a code block spans pages. The truncation notice is plain.
+func splitFormatted(message formattedMessage) []formattedMessage {
+	const suffix = "\n... (truncated)"
+	var pages []formattedMessage
+	text := message.Text
+	offset := 0
+	for {
+		limit := maxMessageLen
+		truncated := len(pages) == maxPages-1 && utf16Len(text) > limit
+		if truncated {
+			limit -= utf16Len(suffix)
+		}
+		cut, units := utf16Cut(text, limit)
+		if cut < len(text) && !truncated {
+			if newline := strings.LastIndexByte(text[:cut], '\n'); newline >= 0 && utf16Len(text[:newline+1]) >= limit/2 {
+				cut = newline + 1
+				units = utf16Len(text[:cut])
+			}
+		}
+		page := formattedMessage{Text: text[:cut]}
+		for _, e := range message.Entities {
+			start := max(e.Offset, offset)
+			end := min(e.Offset+e.Length, offset+units)
+			if end > start {
+				e.Offset = start - offset
+				e.Length = end - start
+				page.Entities = append(page.Entities, e)
+			}
+		}
+		if truncated {
+			page.Text += suffix
+		}
+		pages = append(pages, page)
+		if cut == len(text) || truncated {
+			return pages
+		}
+		text = text[cut:]
+		offset += units
+	}
+}
+
+func utf16Cut(s string, limit int) (int, int) {
+	units := 0
+	for i, r := range s {
+		width := 1
+		if r > 0xffff {
+			width = 2
+		}
+		if units+width > limit {
+			return i, units
+		}
+		units += width
+	}
+	return len(s), units
+}
+
+// Invalid UTF-8 cannot be represented faithfully in JSON. Normalize before
+// measuring entity offsets so encoding/json cannot change their meaning.
+func renderMessages(s string) []formattedMessage {
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "\uFFFD")
+	}
+	return splitFormatted(formatMessage(s))
+}

--- a/internal/bridge/telegram/formatting_test.go
+++ b/internal/bridge/telegram/formatting_test.go
@@ -1,0 +1,133 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestFormatMessage(t *testing.T) {
+	tests := []struct {
+		name, source, text string
+		entities           []textEntity
+	}{
+		{"plain", "<b>x</b> & a_b /tmp/a_b\n• punkt\n1. steg", "<b>x</b> & a_b /tmp/a_b\n• punkt\n1. steg", nil},
+		{"bold", "**Status**\n\n• **Klar**", "Status\n\n• Klar", []textEntity{{Type: "bold", Offset: 0, Length: 6}, {Type: "bold", Offset: 10, Length: 4}}},
+		{"emoji", "🐕 **Blå** `æøå`", "🐕 Blå æøå", []textEntity{{Type: "bold", Offset: 3, Length: 3}, {Type: "code", Offset: 7, Length: 3}}},
+		{"literal code", "`**x** <b> & a_b`", "**x** <b> & a_b", []textEntity{{Type: "code", Offset: 0, Length: 15}}},
+		{"fence", "Kjør:\n```bash\nprintf '**x** & < >'\n```\nFerdig", "Kjør:\nprintf '**x** & < >'\nFerdig", []textEntity{{Type: "pre", Offset: 6, Length: 21, Language: "bash"}}},
+		{"unclosed", "**åpen og `åpen", "**åpen og `åpen", nil},
+		{"unfinished block", "```sh\n**literal** `literal`", "```sh\n**literal** `literal`", nil},
+		{"unsupported delimiters", "``x`` ***y***", "``x`` ***y***", nil},
+		{"empty", "```\n```", "```\n```", nil},
+		{"two blocks", "```\nx\n```\n\n```go\ny\n```", "x\n\ny\n", []textEntity{{Type: "pre", Offset: 0, Length: 2}, {Type: "pre", Offset: 3, Length: 2, Language: "go"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatMessage(tt.source)
+			if got.Text != tt.text || !reflect.DeepEqual(got.Entities, tt.entities) {
+				t.Fatalf("got %#v; want text %q entities %#v", got, tt.text, tt.entities)
+			}
+		})
+	}
+}
+
+func TestFormattedPagination(t *testing.T) {
+	for _, token := range []string{"x", "ø", "🐕"} {
+		t.Run(token, func(t *testing.T) {
+			body := strings.Repeat(token, 4500) + "\n"
+			pages := renderMessages("```text\n" + body + "```")
+			var joined strings.Builder
+			for _, page := range pages {
+				if !utf8.ValidString(page.Text) || utf16Len(page.Text) > maxMessageLen {
+					t.Fatalf("invalid page")
+				}
+				if len(page.Entities) != 1 || page.Entities[0].Offset != 0 || page.Entities[0].Length != utf16Len(page.Text) || page.Entities[0].Type != "pre" {
+					t.Fatalf("bad entity: %#v", page.Entities)
+				}
+				joined.WriteString(page.Text)
+			}
+			if joined.String() != body {
+				t.Fatal("pagination lost content")
+			}
+		})
+	}
+}
+
+func TestFormattingTruncation(t *testing.T) {
+	pages := renderMessages("**" + strings.Repeat("🐕", 9000) + "**")
+	if len(pages) != maxPages {
+		t.Fatalf("pages %d", len(pages))
+	}
+	last := pages[len(pages)-1]
+	suffix := "\n... (truncated)"
+	if !strings.HasSuffix(last.Text, suffix) {
+		t.Fatal("missing notice")
+	}
+	if last.Entities[0].Length != utf16Len(strings.TrimSuffix(last.Text, suffix)) {
+		t.Fatal("notice styled or bad offset")
+	}
+	for _, page := range pages {
+		if !utf8.ValidString(page.Text) || utf16Len(page.Text) > maxMessageLen {
+			t.Fatal("invalid page")
+		}
+	}
+}
+
+func TestSendFormattingEntities(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		if got := r.FormValue("text"); got != "🐕 Status\nKjør h2o list" {
+			t.Errorf("text %q", got)
+		}
+		if r.FormValue("parse_mode") != "" {
+			t.Error("must not use parse_mode")
+		}
+		var entities []textEntity
+		if err := json.Unmarshal([]byte(r.FormValue("entities")), &entities); err != nil {
+			t.Error(err)
+		}
+		want := []textEntity{{Type: "bold", Offset: 3, Length: 6}, {Type: "code", Offset: 15, Length: 8}}
+		if !reflect.DeepEqual(entities, want) {
+			t.Errorf("entities %#v", entities)
+		}
+		json.NewEncoder(w).Encode(apiResponse{OK: true})
+	}))
+	defer srv.Close()
+	tg := &Telegram{Token: "TOKEN", ChatID: 42, BaseURL: srv.URL}
+	if err := tg.Send(context.Background(), "🐕 **Status**\nKjør `h2o list`"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func FuzzRenderMessages(f *testing.F) {
+	for _, s := range []string{"🐕 **klar**", "```sh\necho x\n```", "`x`", "\xff**x**", strings.Repeat("🐕", 9000)} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		pages := renderMessages(s)
+		if len(pages) > maxPages {
+			t.Fatal("too many pages")
+		}
+		for _, p := range pages {
+			n := utf16Len(p.Text)
+			if !utf8.ValidString(p.Text) || n > maxMessageLen {
+				t.Fatal("invalid text")
+			}
+			lastEnd := 0
+			for _, e := range p.Entities {
+				if e.Offset < lastEnd || e.Length <= 0 || e.Offset+e.Length > n {
+					t.Fatalf("invalid entity %#v", e)
+				}
+				lastEnd = e.Offset + e.Length
+			}
+		}
+	})
+}

--- a/internal/bridge/telegram/telegram.go
+++ b/internal/bridge/telegram/telegram.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"h2/internal/bridge"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
 	"time"
-
-	"h2/internal/bridge"
 )
 
 var (
@@ -66,7 +65,7 @@ func (t *Telegram) apiURL(method string) string {
 // Telegram's 4096-character limit are split into multiple messages at line
 // boundaries when possible, up to maxPages messages.
 func (t *Telegram) Send(ctx context.Context, text string) error {
-	chunks := bridge.SplitMessage(text, maxMessageLen, maxPages)
+	chunks := renderMessages(text)
 	for _, chunk := range chunks {
 		if err := t.sendChunk(ctx, chunk); err != nil {
 			return err
@@ -75,11 +74,19 @@ func (t *Telegram) Send(ctx context.Context, text string) error {
 	return nil
 }
 
-func (t *Telegram) sendChunk(ctx context.Context, text string) error {
-	resp, err := t.client.PostForm(t.apiURL("sendMessage"), url.Values{
+func (t *Telegram) sendChunk(ctx context.Context, message formattedMessage) error {
+	fields := url.Values{
 		"chat_id": {strconv.FormatInt(t.ChatID, 10)},
-		"text":    {text},
-	})
+		"text":    {message.Text},
+	}
+	if len(message.Entities) > 0 {
+		encoded, err := json.Marshal(message.Entities)
+		if err != nil {
+			return fmt.Errorf("telegram send: encode entities: %w", err)
+		}
+		fields.Set("entities", string(encoded))
+	}
+	resp, err := t.client.PostForm(t.apiURL("sendMessage"), fields)
 	if err != nil {
 		return fmt.Errorf("telegram send: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Render a deliberately small outgoing Telegram syntax: `**bold**`, inline code, and fenced code blocks with optional language labels.
- Send native text entities rather than parse_mode, keeping shell operators, paths, HTML and other literal text safe from Telegram escaping rules.
- Paginate with UTF-16-aware lengths and UTF-8-safe cuts; clip/rebase entities across pages and leave the existing three-page truncation notice unstyled.
- Preserve paragraphs/lists, document unsupported syntax, and add unit, HTTP boundary, Unicode/pagination and fuzz tests. No extra dependency or Telegram SDK.

## Scope
This is an independent follow-up to #29, based directly on main, with no image changes included. Image captions, stored messages, and other bridges remain unchanged. No terminal color emulation or full Markdown renderer is introduced.

## Validation
- This main-based branch: `make check` and `go test ./internal/bridge/telegram ./internal/bridgeservice -count=1` passed.
- Equivalent formatting change combined with #29: `make check`, full `make test`, fresh `go test ./tests/external -count=1`, targeted transport `-race`, and a short two-worker renderer fuzz run passed; binary built successfully.
- Combined build activated with operator approval; live Telegram API accepted a message containing bold, inline code and a fenced code block. Client-side visual acceptance is still pending operator feedback.

The image PR uses context-aware HTTP for sendMessage; this standalone branch intentionally preserves main's existing HTTP call to keep the two changes independent. A merge of both will require reconciling that small sendChunk hunk.
